### PR TITLE
Added metabase helm chart support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,13 @@ helm repo add eks http://code.mx51.io/helm-chart-packages/
 ```
 
 ### AWS Calico
+
 * [aws-calico](stable/aws-calico): Install Calico network policy enforcement on AWS
+* [metabase](stable/metabase): Install Metabase
+
+### Local testing
+
+```sh
+# For example to generate the template for Metabase
+helm template metabase stable/metabase -n data -f stable/metabase/values.yaml --set serviceAccount.create=true
+```

--- a/stable/metabase/.helmignore
+++ b/stable/metabase/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/metabase/Chart.yaml
+++ b/stable/metabase/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+description: The easy, open source way for everyone in your company to ask questions
+  and learn from data.
+name: metabase
+version: 0.13.2
+appVersion: v0.36.3
+maintainers:
+- name: pmint93
+  email: phamminhthanh69@gmail.com
+home: http://www.metabase.com/
+icon: http://www.metabase.com/images/logo.svg
+sources:
+- https://github.com/metabase/metabase

--- a/stable/metabase/OWNERS
+++ b/stable/metabase/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- pmint93
+reviewers:
+- pmint93

--- a/stable/metabase/README.md
+++ b/stable/metabase/README.md
@@ -1,0 +1,119 @@
+# Metabase
+
+[Metabase](http://metabase.com) is the easy, open source way for everyone in your company to ask questions and learn from data.
+
+## Introduction
+
+This chart bootstraps a [Metabase](https://github.com/metabase/metabase) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.4+
+
+## Get Repo Info
+
+```bash
+helm repo add pmint93 https://pmint93.github.io/helm-charts
+helm repo update
+```
+
+See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation.
+
+## Installing the Chart
+
+```bash
+# Helm 3
+$ helm install [RELEASE_NAME] pmint93/metabase
+
+# Helm 2
+$ helm install --name [RELEASE_NAME] pmint93/metabase
+```
+
+The command deploys Metabase on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+```bash
+# Helm 3
+$ helm uninstall [RELEASE_NAME]
+
+# Helm 2
+# helm delete --purge [RELEASE_NAME]
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Metabase chart and their default values.
+
+| Parameter                        | Description                                                 | Default           |
+| -------------------------------  | ----------------------------------------------------------- | ----------------- |
+| replicaCount                     | desired number of controller pods                           | 1                 |
+| podAnnotations                   | controller pods annotations                                 | {}                |
+| podLabels                        | extra pods labels                                           | {}                |
+| image.repository                 | controller container image repository                       | metabase/metabase |
+| image.tag                        | controller container image tag                              | v0.36.3           |
+| image.pullPolicy                 | controller container image pull policy                      | IfNotPresent      |
+| fullnameOverride                 | String to fully override metabase.fullname template         | null              |
+| listen.host                      | Listening on a specific network host                        | 0.0.0.0           |
+| listen.port                      | Listening on a specific network port                        | 3000              |
+| ssl.enabled                      | Enable SSL to run over HTTPS                                | false             |
+| ssl.port                         | SSL port                                                    | null              |
+| ssl.keyStore                     | The key store in JKS format                                 | null              |
+| ssl.keyStorePassword             | The password for key Store                                  | null              |
+| database.type                    | Backend database type                                       | h2                |
+| database.encryptionKey           | Secret key for encrypt sensitive information into database  | null              |
+| database.connectionURI           | Database connection URI (alternative to the below settings) | null              |
+| database.host                    | Database host                                               | null              |
+| database.port                    | Database port                                               | null              |
+| database.dbname                  | Database name                                               | null              |
+| database.username                | Database username                                           | null              |
+| database.password                | Database password                                           | null              |
+| database.existingSecret          | Exising secret for database credentials                     | null              |
+| database.existingSecretUsernameKey | Username key for exising secret                           | null              |
+| database.existingSecretPasswordKey | Password key for exising secret                           | null              |
+| database.existingSecretConnectionURIKey | ConnectionURI key for exising secret                 | null              |
+| password.complexity              | Complexity requirement for Metabase account's password      | normal            |
+| password.length                  | Minimum length required for Metabase account's password     | 6                 |
+| timeZone                         | Service time zone                                           | UTC               |
+| emojiLogging                     | Get a funny emoji in service log                            | true              |
+| javaOpts                         | JVM options                                                 | null              |
+| pluginsDirectory                 | A directory with Metabase plugins                           | null              |
+| livenessProbe.initialDelaySeconds | Delay before liveness probe is initiated                   | 120               |
+| livenessProbe.timeoutSeconds     | When the probe times out                                    | 30                |
+| livenessProbe.failureThreshold   | Minimum consecutive failures for the probe                  | 6                 |
+| readinessProbe.initialDelaySeconds | Delay before readiness probe is initiated                 | 30                |
+| readinessProbe.timeoutSeconds    | When the probe times out                                    | 3                 |
+| readinessProbe.periodSeconds     | How often to perform the probe                              | 5                 |
+| service.type                     | ClusterIP, NodePort, or LoadBalancer                        | ClusterIP         |
+| service.loadBalancerSourceRanges | Array of Source Ranges                                      | null              |
+| service.externalPort             | Service external port                                       | 80                |
+| service.internalPort             | Service internal port, should be the same as `listen.port`  | 3000              |
+| service.nodePort                 | Service node port                                           | null              |
+| service.annotations              | Service annotations                                         | {}                |
+| serviceAccount.create            | Specifies whether a service account should be created       | false             |
+| serviceAccount.annotations       | Annotations to add to the service account                   | {}                |
+| serviceAccount.name              | The name of the service account to use                      | null              |
+| ingress.enabled                  | Enable ingress controller resource                          | false             |
+| ingress.hosts                    | Ingress resource hostnames                                  | null              |
+| ingress.path                     | Ingress path                                                | /                 |
+| ingress.labels                   | Ingress labels configuration                                | null              |
+| ingress.annotations              | Ingress annotations configuration                           | {}                |
+| ingress.tls                      | Ingress TLS configuration                                   | null              |
+| log4jProperties                  | Custom `log4j.properties` file                              | null              |
+| resources                        | Server resource requests and limits                         | {}                |
+| nodeSelector                     | Node labels for pod assignment                              | {}                |
+| tolerations                      | Toleration labels for pod assignment                        | []                |
+| affinity                         | Affinity settings for pod assignment                        | {}                |
+| jetty.maxThreads                 | Jetty max number of threads                                 | null              |
+| jetty.minThreads                 | Jetty min number of threads                                 | null              |
+| jetty.maxQueued                  | Jetty max queue size                                        | null              |
+| jetty.maxIdleTime                | Jetty max idle time                                         | null              |
+| siteUrl                          | Base URL, useful for serving behind a reverse proxy         | null              |
+| session.maxSessionAge            | Session expiration defined in minutes                       | 20160             |
+| session.sessionCookies           | When browser is closed, user login session will expire      | null              |
+
+The above parameters map to the env variables defined in [metabase](http://github.com/metabase/metabase). For more information please refer to the [metabase documentations](http://www.metabase.com/docs/v0.36.3/).

--- a/stable/metabase/templates/NOTES.txt
+++ b/stable/metabase/templates/NOTES.txt
@@ -1,0 +1,17 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.hostname }}
+  http://{{- .Values.ingress.hostname }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "metabase.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "metabase.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "metabase.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "metabase.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:{{ .Values.service.internalPort }}
+{{- end }}

--- a/stable/metabase/templates/_helpers.tpl
+++ b/stable/metabase/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "metabase.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "metabase.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the apiVersion of deployment.
+*/}}
+{{- define "deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "metabase.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "metabase.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/metabase/templates/config.yaml
+++ b/stable/metabase/templates/config.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "metabase.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  {{- if .Values.log4jProperties }}
+  log4j.properties:
+{{ toYaml .Values.log4jProperties | indent 4}}
+  {{- end}}

--- a/stable/metabase/templates/database-secret.yaml
+++ b/stable/metabase/templates/database-secret.yaml
@@ -1,0 +1,23 @@
+{{- if and (ne (.Values.database.type | lower) "h2") (not .Values.database.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "metabase.fullname" . }}-database
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  {{- if .Values.database.encryptionKey }}
+  encryptionKey: {{ .Values.database.encryptionKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.database.connectionURI }}
+  connectionURI: {{ .Values.database.connectionURI | b64enc | quote }}
+  {{- else }}
+  username: {{ .Values.database.username | b64enc | quote }}
+  password: {{ .Values.database.password | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/stable/metabase/templates/deployment.yaml
+++ b/stable/metabase/templates/deployment.yaml
@@ -1,0 +1,173 @@
+apiVersion: {{ template "deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ template "metabase.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "metabase.name" . }}
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+        {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | trim | indent 8 }}
+        {{- end }}
+      labels:
+        app: {{ template "metabase.name" . }}
+        release: {{ .Release.Name }}
+        {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | trim | indent 8 }}
+        {{- end }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          - name: MB_JETTY_HOST
+            value: {{ .Values.listen.host | quote }}
+          - name: MB_JETTY_PORT
+            value: {{ .Values.listen.port | quote }}
+          {{- if .Values.ssl.enabled }}
+          - name: MB_JETTY_SSL
+            value: true
+          - name: MB_JETTY_SSL_Port
+            value: {{ .Values.ssl.port | quote }}
+          - name: MB_JETTY_SSL_Keystore
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "metabase.fullname" . }}-ssl
+                key: keystore
+          - name: MB_JETTY_SSL_Keystore_Password
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "metabase.fullname" . }}-ssl
+                key: password
+          {{- end }}
+          {{- if .Values.jetty }}
+            {{- range $key, $value := .Values.jetty }}
+          - name: MB_JETTY_{{ $key | upper }}
+            value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          - name: MB_DB_TYPE
+            value: {{ .Values.database.type | lower }}
+          {{- if .Values.database.encryptionKey }}
+          - name: MB_ENCRYPTION_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "metabase.fullname" . }}-database
+                key: encryptionKey
+          {{- end }}
+          {{- if ne (.Values.database.type | lower) "h2" }}
+            {{- if or .Values.database.existingSecretConnectionURIKey .Values.database.connectionURI }}
+          - name: MB_DB_CONNECTION_URI
+            valueFrom:
+              secretKeyRef:
+                name: {{ or .Values.database.existingSecret (printf "%s-database" (include "metabase.fullname" .)) }}
+                key: {{ or .Values.database.existingSecretConnectionURIKey "connectionURI" }}
+            {{- else }}
+          - name: MB_DB_HOST
+            value: {{ .Values.database.host | quote }}
+          - name: MB_DB_PORT
+            value: {{ .Values.database.port | quote }}
+          - name: MB_DB_DBNAME
+            value: {{ .Values.database.dbname | quote }}
+          - name: MB_DB_USER
+            valueFrom:
+              secretKeyRef:
+                name: {{ or .Values.database.existingSecret (printf "%s-database" (include "metabase.fullname" .)) }}
+                key: {{ or .Values.database.existingSecretUsernameKey "username" }}
+          - name: MB_DB_PASS
+            valueFrom:
+              secretKeyRef:
+                name: {{ or .Values.database.existingSecret (printf "%s-database" (include "metabase.fullname" .)) }}
+                key: {{ or .Values.database.existingSecretPasswordKey "password" }}
+            {{- end }}
+          {{- end }}
+          - name: MB_PASSWORD_COMPLEXITY
+            value: {{ .Values.password.complexity }}
+          - name: MB_PASSWORD_LENGTH
+            value: {{ .Values.password.length | quote }}
+          - name: JAVA_TIMEZONE
+            value: {{ .Values.timeZone }}
+          {{- if .Values.javaOpts }}
+          - name: JAVA_OPTS
+            value: {{ .Values.javaOpts | quote }}
+          {{- else }}
+            {{- if .Values.log4jProperties }}
+          - name: JAVA_OPTS
+            value: "-Dlog4j.configuration=file:/tmp/conf/log4j.properties"
+            {{- end }}
+          {{- end }}
+          {{- if .Values.pluginsDirectory }}
+          - name: MB_PLUGINS_DIR
+            value: {{ .Values.pluginsDirectory | quote }}
+          {{- end }}
+          - name: MB_EMOJI_IN_LOGS
+            value: {{ .Values.emojiLogging | quote }}
+          {{- if .Values.siteUrl }}
+          - name: MB_SITE_URL
+            value: {{ .Values.siteUrl | quote }}
+          {{- end }}
+          {{- if .Values.session.maxSessionAge }}
+          - name: MAX_SESSION_AGE
+            value: {{ .Values.session.maxSessionAge | quote }}
+          {{- end }}
+          {{- if .Values.session.sessionCookies }}
+          - name: MB_SESSION_COOKIES
+            value: {{ .Values.session.sessionCookies | quote }}
+          {{- end }}
+          ports:
+            - containerPort: {{ .Values.service.internalPort }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.service.internalPort }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.service.internalPort }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          {{- if .Values.log4jProperties }}
+          volumeMounts:
+            - name: config
+              mountPath: /tmp/conf/
+          {{- end}}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      serviceAccountName: {{ template "metabase.serviceAccountName" . }}
+      volumes:
+        {{- if .Values.log4jProperties}}
+        - name: config
+          configMap:
+            name: {{ template "metabase.fullname" . }}-config
+            items:
+            - key: log4j.properties
+              path: log4j.properties
+        {{- end }}

--- a/stable/metabase/templates/ingress.yaml
+++ b/stable/metabase/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "metabase.fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "metabase.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- range $key, $value := .Values.ingress.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/stable/metabase/templates/service.yaml
+++ b/stable/metabase/templates/service.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "metabase.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+{{- if .Values.service.loadBalancerSourceRanges}}
+  loadBalancerSourceRanges:
+{{toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+{{- end}}
+  ports:
+    - port: {{ .Values.service.externalPort }}
+      targetPort: {{ .Values.service.internalPort }}
+{{- if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+{{- end}}
+      protocol: TCP
+      name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "metabase.name" . }}
+    release: {{ .Release.Name }}

--- a/stable/metabase/templates/serviceaccount.yaml
+++ b/stable/metabase/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "metabase.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/stable/metabase/templates/ssl-secret.yaml
+++ b/stable/metabase/templates/ssl-secret.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.ssl.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "metabase.fullname" . }}-ssl
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  keystore: {{ .Values.ssl.keystore | b64enc | quote }}
+  password: {{ .Values.ssl.keyStorePassword | b64enc | quote }}
+{{- end }}

--- a/stable/metabase/values.yaml
+++ b/stable/metabase/values.yaml
@@ -1,0 +1,150 @@
+# Currently Metabase is not horizontly scalable. See
+# https://github.com/metabase/metabase/issues/1446 and
+# https://github.com/metabase/metabase/issues/2754
+# NOTE: Should remain 1
+replicaCount: 1
+podAnnotations: {}
+podLabels: {}
+image:
+  repository: metabase/metabase
+  tag: v0.36.3
+  pullPolicy: IfNotPresent
+
+## String to fully override metabase.fullname template
+##
+# fullnameOverride:
+
+# Config Jetty web server
+listen:
+  host: "0.0.0.0"
+  port: 3000
+ssl:
+  # If you have an ssl certificate and would prefer to have Metabase run over HTTPS
+  enabled: false
+  # port: 8443
+  # keyStore: |-
+  #   << JKS KEY STORE >>
+  # keyStorePassword: storepass
+jetty:
+#  maxThreads: 254
+#  minThreads: 8
+#  maxQueued: -1
+#  maxIdleTime: 60000
+
+# Backend database
+database:
+  # Database type (h2 / mysql / postgres), default: h2
+  type: h2
+  # encryptionKey: << YOUR ENCRYPTION KEY >>
+  ## Only need when you use mysql / postgres
+  # host:
+  # port:
+  # dbname:
+  # username:
+  # password:
+  ## Alternatively, use a connection URI for full configurability. Example for SSL enabled Postgres.
+  # connectionURI: postgres://user:password@host:port/database?ssl=true&sslmode=require&sslfactory=org.postgresql.ssl.NonValidatingFactory"
+  ## If a secret with the database credentials already exists, use the following values:
+  # existingSecret:
+  # existingSecretUsernameKey:
+  # existingSecretPasswordKey:
+  # existingSecretConnectionURIKey:
+
+password:
+  # Changing Metabase password complexity:
+  # weak: no character constraints
+  # normal: at least 1 digit (default)
+  # strong: minimum 8 characters w/ 2 lowercase, 2 uppercase, 1 digit, and 1 special character
+  complexity: normal
+  length: 6
+
+timeZone: UTC
+emojiLogging: true
+# javaOpts:
+# pluginsDirectory:
+# siteUrl:
+
+session: {}
+  # maxSessionAge:
+  # sessionCookies:
+
+livenessProbe:
+  initialDelaySeconds: 120
+  timeoutSeconds: 30
+  failureThreshold: 6
+
+readinessProbe:
+  initialDelaySeconds: 30
+  timeoutSeconds: 3
+  periodSeconds: 5
+
+service:
+  name: metabase
+  type: ClusterIP
+  externalPort: 80
+  internalPort: 3000
+  # Used to fix NodePort when service.type: NodePort.
+  nodePort:
+  annotations: {}
+    # Used to add custom annotations to the Service.
+    # service.beta.kubernetes.io/aws-load-balancer-internal: "0.0.0.0/0"
+ingress:
+  enabled: false
+  # Used to create Ingress record (should used with service.type: ClusterIP).
+  hosts:
+    # - metabase.domain.com
+  # The ingress path. Useful to host metabase on a subpath, such as `/metabase`.
+  path: /
+  labels:
+    # Used to add custom labels to the Ingress
+    # Useful if for example you have multiple Ingress controllers and want your Ingress controllers to bind to specific Ingresses
+    # traffic: internal
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: metabase-tls
+    #   hosts:
+    #     - metabase.domain.com
+
+# A custom log4j.properties file can be provided using a multiline YAML string.
+# See https://github.com/metabase/metabase/blob/master/resources/log4j.properties
+#
+# log4jProperties:
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+## Node labels for pod assignment
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+#
+nodeSelector: {}
+
+## Tolerations for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+
+## Affinity for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}


### PR DESCRIPTION
Added metabase 0.13.1 from https://github.com/pmint93/helm-charts, then added service-account creation to be able to provide a custom service-account.
This is required in our case as we need to access AWS resources such as SSM and KMS