### PR TITLE
Reverting from 3.18.1 to 3.15.5 to fix route deletion on pod going into terminating state

### DIFF
--- a/stable/aws-calico/Chart.yaml
+++ b/stable/aws-calico/Chart.yaml
@@ -3,6 +3,6 @@ description: A Helm chart for installing Calico on AWS
 # Commenting `website` as it fails Yamale strict mode
 # website: https://docs.aws.amazon.com/eks/latest/userguide/calico.html
 name: aws-calico
-version: 0.0.10
-appVersion: 3.18.1
+version: 0.0.11
+appVersion: 3.15.1
 icon: https://www.projectcalico.org/wp-content/uploads/2019/09/Calico_Logo_Large_Calico.png

--- a/stable/aws-calico/README.md
+++ b/stable/aws-calico/README.md
@@ -51,7 +51,7 @@ The following table lists the configurable parameters for this chart and their d
 | `calico.node.nodeSelector`             | Calico Node Node Selector                               | `{ beta.kubernetes.io/os: linux }` |
 | `calico.typha_autoscaler.resources`    | Calico Typha Autoscaler Resources                       | `requests.memory: 16Mi, requests.cpu: 10m, limits.memory: 32Mi, limits.cpu: 10m` |
 | `calico.typha_autoscaler.nodeSelector` | Calico Typha Autoscaler Node Selector                   | `{ beta.kubernetes.io/os: linux }` |
-| `calico.tag`                           | Calico version                                          | `v3.15.1`                       |
+| `calico.tag`                           | Calico version                                          | `v3.15.5`                       |
 | `fullnameOverride`                     | Override the fullname of the chart                      | `calico`                        |
 | `podSecurityPolicy.create`             | Specifies whether podSecurityPolicy and related rbac objects should be created  | `false` |
 | `serviceAccount.name`                  | The name of the ServiceAccount to use                   | `nil`                           |

--- a/stable/aws-calico/values.yaml
+++ b/stable/aws-calico/values.yaml
@@ -7,7 +7,7 @@ podSecurityPolicy:
   create: false
 
 calico:
-  tag: v3.15.1
+  tag: v3.15.5
 
   typha:
     logseverity: Info   # Debug, Info, Warning, Error, Fatal

--- a/stable/aws-calico/values.yaml
+++ b/stable/aws-calico/values.yaml
@@ -7,7 +7,7 @@ podSecurityPolicy:
   create: false
 
 calico:
-  tag: v3.18.1
+  tag: v3.15.1
 
   typha:
     logseverity: Info   # Debug, Info, Warning, Error, Fatal


### PR DESCRIPTION
The problem we have had was introduced in 3.16.
Open issue https://github.com/projectcalico/calico/issues/4518
