### PR TITLE
Updating release of Calico to 3.19.3 and a fix in K8s 1.20+ on missing probes timeout

### DIFF
--- a/stable/aws-calico/Chart.yaml
+++ b/stable/aws-calico/Chart.yaml
@@ -3,6 +3,6 @@ description: A Helm chart for installing Calico on AWS
 # Commenting `website` as it fails Yamale strict mode
 # website: https://docs.aws.amazon.com/eks/latest/userguide/calico.html
 name: aws-calico
-version: 0.0.13
-appVersion: 3.19.2
+version: 0.0.14
+appVersion: 3.19.3
 icon: https://www.projectcalico.org/wp-content/uploads/2019/09/Calico_Logo_Large_Calico.png

--- a/stable/aws-calico/templates/daemon-set.yaml
+++ b/stable/aws-calico/templates/daemon-set.yaml
@@ -109,12 +109,14 @@ spec:
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6
+            timeoutSeconds: 5
           readinessProbe:
             exec:
               command:
                 - /bin/calico-node
                 - -felix-ready
             periodSeconds: 10
+            timeoutSeconds: 5
           resources:
             {{- toYaml .Values.calico.node.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
Release notes for Calico 3.19.3: https://docs.projectcalico.org/archive/v3.19/release-notes/

Fix for EKS: https://github.com/aws/eks-charts/issues/574