### PR TITLE
[patch] Adding deployment annotations

### DIFF
--- a/stable/ssm-secrets-webhook/Chart.yaml
+++ b/stable/ssm-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: 1.3.2
-version: 0.2.2
+version: 0.2.3
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from AWS SSM
 name: ssm-secrets-webhook
 maintainers:

--- a/stable/ssm-secrets-webhook/templates/webhook-deployment.yaml
+++ b/stable/ssm-secrets-webhook/templates/webhook-deployment.yaml
@@ -3,6 +3,10 @@ kind: Deployment
 metadata:
   name: {{ template "ssm-secrets-webhook.fullname" . }}
   namespace: {{ .Release.Namespace }}
+    annotations:
+      {{- with .Values.deploymentAnnotations }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/name: {{ template "ssm-secrets-webhook.name" . }}

--- a/stable/ssm-secrets-webhook/values.yaml
+++ b/stable/ssm-secrets-webhook/values.yaml
@@ -44,6 +44,8 @@ volumes: []
 
 volumeMounts: []
 
+deploymentAnnotations: {}
+
 podAnnotations: {}
 
 labels: {}
@@ -65,7 +67,7 @@ rbac:
     enabled: false
 
 # A list of Kubernetes resource types to mutate as well:
-# Example: ["ingresses", "servicemonitors"] 
+# Example: ["ingresses", "servicemonitors"]
 customResourceMutations: []
 
 customResourcesFailurePolicy: Ignore


### PR DESCRIPTION
In order to use [reloader](https://github.com/stakater/Reloader) for an automatic restart of ssm-secrest-webhook, we require to annotate the deployment. 